### PR TITLE
Fix ScopeFailure/ScopeSuccess for C++20 and later

### DIFF
--- a/include/ScopeExit/ScopeFailure.h
+++ b/include/ScopeExit/ScopeFailure.h
@@ -24,11 +24,11 @@ namespace ScopeExit
         
         ~ScopeFailure()
         { 
-            #if __cplusplus >= 201703L
+#if __cplusplus >= 201703L
             if (std::uncaught_exceptions())
-            #else
+#else
             if (std::uncaught_exception())
-            #endif
+#endif
             {
                 m_fn();
             }

--- a/include/ScopeExit/ScopeFailure.h
+++ b/include/ScopeExit/ScopeFailure.h
@@ -24,7 +24,11 @@ namespace ScopeExit
         
         ~ScopeFailure()
         { 
+            #if __cplusplus >= 201703L
+            if (std::uncaught_exceptions())
+            #else
             if (std::uncaught_exception())
+            #endif
             {
                 m_fn();
             }

--- a/include/ScopeExit/ScopeSuccess.h
+++ b/include/ScopeExit/ScopeSuccess.h
@@ -5,7 +5,7 @@
 //
 // Usage:
 //
-// SCOPE_SUCCESS{ cout << "hello"; }; // will be called at the scope success in case of success (no exception is thrown)
+// SCOPE_SUCCESS{ cout << "hello"; }; // will be called at the scope exit in case of success (no exception is thrown)
 //
 
 #define SCOPE_SUCCESS_CAT2(x, y) x##y
@@ -24,7 +24,11 @@ namespace ScopeExit
         
         ~ScopeSuccess()
         { 
+            #if __cplusplus >= 201703L
+            if (!std::uncaught_exceptions())
+            #else
             if (!std::uncaught_exception())
+            #endif
             {
                 m_fn();
             }

--- a/include/ScopeExit/ScopeSuccess.h
+++ b/include/ScopeExit/ScopeSuccess.h
@@ -24,11 +24,11 @@ namespace ScopeExit
         
         ~ScopeSuccess()
         { 
-            #if __cplusplus >= 201703L
+#if __cplusplus >= 201703L
             if (!std::uncaught_exceptions())
-            #else
+#else
             if (!std::uncaught_exception())
-            #endif
+#endif
             {
                 m_fn();
             }


### PR DESCRIPTION
`std::uncaught_exception` was deprecated in C++17 and removed in C++20
Fix ScopeFailure and ScopeSuccess for C++20 and later